### PR TITLE
Replace hard-coded exa with $LS

### DIFF
--- a/bm
+++ b/bm
@@ -39,7 +39,7 @@ case "$COMMAND" in
     BOOKMARK="${2:-}"
     RESOLVED="$($BM --resolve "${BOOKMARK}")"
     echo "$(tput smul; tput bold)${RESOLVED}$(tput sgr0)"
-    exa -1 "${RESOLVED}"
+    $LS -1 "${RESOLVED}"
     ;;
 
   --resolve)


### PR DESCRIPTION
Line 42 had a hard-coded call to exa instead of $LS, the variable that exists to only call exa if exa is installed.